### PR TITLE
fix: mvp+ supports '+' color change

### DIFF
--- a/src/helpers/PlayerRank.ts
+++ b/src/helpers/PlayerRank.ts
@@ -275,6 +275,9 @@ export function getPlayerRank(
           customPlusColor as keyof typeof MinecraftColorAsHex
         ];
     }
+    if (out.priority === PlayerRanks.MVP_PLUS) {
+      out.prefix = `§b[MVP${customPlusColor ?? "§c"}+§b]`;
+    }
     if (out.priority === PlayerRanks.SUPERSTAR) {
       out.prefix = `${customRankColor ?? "§6"}[MVP${customPlusColor ?? "§c"}++${
         customRankColor ?? "§6"

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -111,6 +111,13 @@ describe("Test PlayerRank helper", function () {
     );
     expect(rank.name).to.be.a("string").that.equals("MVP_PLUS");
   });
+  it("should return MVP+ with black +", function () {
+    const rank = getPlayerRank(
+      { newPackageRank: "MVP_PLUS", rankPlusColor: "BLACK" } as never,
+      false
+    );
+    expect(rank.prefix).to.be.a("string").that.equals("§b[MVP§0+§b]");
+  });
   it("should return MVP", function () {
     const rank = getPlayerRank(
       { newPackageRank: "MVP", packageRank: "VIP" } as never,


### PR DESCRIPTION
This pull request introduces an improvement to the way MVP+ player ranks are displayed, specifically addressing the color formatting of the "+" symbol in the prefix. It also adds a corresponding test to ensure this behavior works as expected.

With MVP+ rank, you can also change the "+" color via IG menu :
<img width="933" height="492" alt="image" src="https://github.com/user-attachments/assets/b5ede73c-e499-471c-b770-074fd36faaae" />
